### PR TITLE
Add Build Pipeline

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,14 @@
+# Ignore everything
+*
+
+# Don't ignore project configuration
+!package.json
+
+# Don't ignore project dependencies
+!node_modules/**
+
+# Don't ignore build artifact
+!lib/**
+
+# Don't ignore working directory
+!.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,7 +9,6 @@ steps:
     entrypoint: yarn
     args: ["test"]
   - name: gcr.io/cloud-builders/gcloud
-    dir: lib
     args:
       [
         "functions",


### PR DESCRIPTION
This PR:

* Introduces a `.gcloudignore` file so that `gcloud functions deploy` knows what should and should not be deployed.
* Introduces a Google Cloud Build pipeline which installs dependencies, and performs a build, test and deployment of the project.